### PR TITLE
Gracefully exit if prettier fails

### DIFF
--- a/lib/jekyll-prettier.rb
+++ b/lib/jekyll-prettier.rb
@@ -13,10 +13,14 @@ else
   Jekyll::Hooks.register :documents, :post_render do |doc|
     puts "Running prettier on doc: " + doc.url
     args = ["prettier", "--parser", "html"]
-    Open3.popen2(*args) do |stdin, stdout, wait_thru|
+    Open3.popen2(*args) do |stdin, stdout, wait_thr|
       stdin.print doc.output
       stdin.close
-      doc.output = stdout.read
+      if wait_thr.value.success?
+        doc.output = stdout.read
+      else
+        puts "Prettier encountered an error while formatting the document " + doc.url
+      end
     end
   end
 
@@ -28,10 +32,14 @@ else
     else
       args = ["prettier", "--stdin-filepath", page.relative_path]
     end
-    Open3.popen2(*args) do |stdin, stdout, wait_thru|
+    Open3.popen2(*args) do |stdin, stdout, wait_thr|
       stdin.print page.output
       stdin.close
-      page.output = stdout.read
+      if wait_thr.value.success?
+        page.output = stdout.read
+      else
+        puts "Prettier encountered an error while formatting the page " + doc.url
+      end
     end
   end
 end


### PR DESCRIPTION
Before this commit, whenever prettier failed the content of the original file would be cleared (on my page for exampe this happened when trying to parse css maps or rss feed xmls, because no parser could be inferred for these filetypes). This is becasue there was no check if the prettier process exited sucessfully and the stdout output would get written either way, even if there was no output.

This commit adds a check for a successful exit of the prettier process and doesn't overwrite the original file if there was an error.